### PR TITLE
Fix logger initialize

### DIFF
--- a/src/bpd/opts.rs
+++ b/src/bpd/opts.rs
@@ -44,10 +44,11 @@ pub struct Opts {
 
 impl Opts {
     pub fn process(&mut self) {
-        self.shared.process();
-        shell_setup(self.shared.verbose, [&mut self.rpc_endpoint], &mut self.shared.data_dir, &[(
-            "{chain}",
-            self.shared.chain.to_string(),
-        )]);
+        shell_setup(
+            self.shared.verbose,
+            [&mut self.rpc_endpoint, &mut self.shared.ctl_endpoint, &mut self.shared.store_endpoint],
+            &mut self.shared.data_dir,
+            &[("{chain}", self.shared.chain.to_string())],
+        );
     }
 }


### PR DESCRIPTION
**Describe the problem**

The bpd daemon don't initialize because the `shell_setup`  is called many times and cause a below error: 
```
bpd: managing bp node daemon
thread 'main' panicked at 'env_logger::init should not be called after logger initialized: SetLoggerError(())'
```

